### PR TITLE
ENDFV2

### DIFF
--- a/cross_sections.cc
+++ b/cross_sections.cc
@@ -21,13 +21,13 @@ struct AtomConsts {
                           const int AX, const int NX, const int ZX,
                           const double sep) const {
     double temp = 15.68 * (AC - AX) -
-                  (28.07 * ((pow(NC - ZC, 2) / AC) - (pow(NX - ZX, 2) / AX))) -
+                  (28.07 * ((pow(NC - ZC, 2) / static_cast<double>(AC)) - (pow(NX - ZX, 2) / static_cast<double>(AX)))) -
                   (18.56 * (pow(AC, 2.0 / 3.0) - pow(AX, 2.0 / 3.0))) +
                   (33.22 * ((pow(NC - ZC, 2) / pow(AC, 4.0 / 3.0)) -
                             (pow(NX - ZX, 2) / pow(AX, 4.0 / 3.0)))) -
                   (0.717 * ((pow(ZC, 2) / pow(AC, 1.0 / 3.0)) -
                             (pow(ZX, 2) / pow(AX, 1.0 / 3.0)))) +
-                  (1.211 * ((pow(ZC, 2) / AC) - (pow(ZX, 2) / AX))) - sep;
+                  (1.211 * ((pow(ZC, 2) / static_cast<double>(AC)) - (pow(ZX, 2) / static_cast<double>(AX)))) - sep;
     return temp;
   }
   AtomConsts(const int a0, const int z0, const int ia, const int iz,

--- a/cross_sections.cc
+++ b/cross_sections.cc
@@ -498,7 +498,7 @@ struct CS_3dENDF {
   }
   CS_3dENDF(const CS_3dENDF &other)
       : energy(other.energy), exit_energy(other.exit_energy), cdf(other.cdf),
-        rvalue(other.cdf) {}
+        rvalue(other.rvalue) {}
 
   CS_3dENDF() : energy(), exit_energy(), cdf(), rvalue() {}
 


### PR DESCRIPTION
Typo in other constructor for the ENDF cross sections, the cdf data was being used for the rvalue, now fixed. 

Fixed integer division occurring in AtomConst struct.